### PR TITLE
Add RVB_durationDialog translations to all locale files

### DIFF
--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_br.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_br.xml
@@ -107,6 +107,7 @@
         <e k="RVB_periodicserviceDayDialog" v="A manutenção do veículo será concluída amanhã às %s horas." tag="format"/>
         <e k="RVB_batteryChDialog" v="Tem certeza de que deseja carregar a bateria do veículo por %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d hora" tag="format"/>
+        <e k="RVB_durationDialog" v="Duração total: %02d hora %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s hora" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Inspeção do veículo em andamento."/>
         <e k="RVB_alertmessage_repair" v="Reparo do veículo em andamento."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_cz.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_cz.xml
@@ -108,6 +108,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Servis vozidla bude dokončen zítra v %s." tag="format"/>
         <e k="RVB_batteryChDialog" v="Jste si jisti, že chcete nabít baterii vozidla za %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d hod." tag="format"/>
+        <e k="RVB_durationDialog" v="Celková doba trvání: %02d hod. %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s hod." tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Probíhá prohlídka vozidla."/>
         <e k="RVB_alertmessage_repair" v="Probíhá oprava vozidla."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_de.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_de.xml
@@ -108,6 +108,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Die Wartung des Fahrzeugs wird morgen um %s Uhr abgeschlossen sein." tag="format"/>
         <e k="RVB_batteryChDialog" v="Sind Sie sicher, dass Sie Ihre Fahrzeugbatterie für %s € aufladen wollen?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d Stunden" tag="format"/>
+        <e k="RVB_durationDialog" v="Gesamtdauer: %02d Stunden %02d Minuten" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s Stunden" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Die Fahrzeuginspektion ist im Gange."/>
         <e k="RVB_alertmessage_repair" v="Die Reparatur des Fahrzeugs ist im Gange."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_en.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_en.xml
@@ -107,6 +107,7 @@
         <e k="RVB_periodicserviceDayDialog" v="The vehicle service will be completed tomorrow at %s o'clock." tag="format"/>
         <e k="RVB_batteryChDialog" v="Are you sure you want to charge the vehicle's battery for %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d hour" tag="format"/>
+        <e k="RVB_durationDialog" v="Total duration: %02d hour %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s hour" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Vehicle inspection in progress."/>
         <e k="RVB_alertmessage_repair" v="Vehicle repair in progress."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_es.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_es.xml
@@ -108,6 +108,7 @@
         <e k="RVB_periodicserviceDayDialog" v="El servicio del vehículo finalizará mañana a las %s." tag="format"/>
         <e k="RVB_batteryChDialog" v="¿Estás seguro de que deseas cargar la batería de tu vehículo por %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d hora" tag="format"/>
+        <e k="RVB_durationDialog" v="Duración total: %02d hora %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s hora" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="La inspección del vehículo está en curso."/>
         <e k="RVB_alertmessage_repair" v="La reparación del vehículo está en curso."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_fr.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_fr.xml
@@ -108,6 +108,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Le service du véhicule se termine demain à %s heures." tag="format"/>
         <e k="RVB_batteryChDialog" v="Es-tu sûr de vouloir charger la batterie du véhicule pour %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d heure" tag="format"/>
+        <e k="RVB_durationDialog" v="Durée totale : %02d heure %02d minute" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s heures" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Inspection du véhicule en cours."/>
         <e k="RVB_alertmessage_repair" v="Réparation du véhicule en cours."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_hu.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_hu.xml
@@ -107,6 +107,7 @@
         <e k="RVB_periodicserviceDayDialog" v="A jármű szervizelése holnap %s órakor fejeződik be." tag="format"/>
         <e k="RVB_batteryChDialog" v="Biztosan felakarod tölteni a jármű akkumulátorát %s áron?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d óra" tag="format"/>
+        <e k="RVB_durationDialog" v="Teljes időtartam: %02d óra %02d perc" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s óra" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Jármű átvizsgálása folyamatban van."/>
         <e k="RVB_alertmessage_repair" v="Jármű javítása folyamatban van."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_it.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_it.xml
@@ -108,6 +108,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Il servizio del veicolo verrà completato domani alle ore %s." tag="format"/>
         <e k="RVB_batteryChDialog" v="Sei sicuro di voler caricare la batteria del veicolo per %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d ore" tag="format"/>
+        <e k="RVB_durationDialog" v="Durata totale: %02d ore %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s ore" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Ispezione del veicolo in corso."/>
         <e k="RVB_alertmessage_repair" v="Riparazione del veicolo in corso."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_nl.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_nl.xml
@@ -109,6 +109,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Het voertuigonderhoud zal morgen om %s uur voltooid zijn." tag="format"/>
         <e k="RVB_batteryChDialog" v="Weet u zeker dat u de accu van uw voertuig wilt opladen voor %s kosten?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d uren" tag="format"/>
+        <e k="RVB_durationDialog" v="Totale duur: %02d uur %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s uur" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Voertuiginspectie is bezig."/>
         <e k="RVB_alertmessage_repair" v="Het voertuig wordt gerepareerd."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_pl.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_pl.xml
@@ -110,6 +110,7 @@
         <e k="RVB_batteryChDialog" v="Czy na pewno chcesz naładować akumulator pojazdu za koszt %s?" tag="format"/>
 
         <e k="RVB_operatingTime" v="%02d godzina" tag="format"/>
+        <e k="RVB_durationDialog" v="Całkowity czas trwania: %02d godz. %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s godzina" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Trwa inspekcja pojazdu."/>
         <e k="RVB_alertmessage_repair" v="Trwa naprawa pojazdu."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_pt.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_pt.xml
@@ -109,6 +109,7 @@
         <e k="RVB_periodicserviceDayDialog" v="O serviço do veículo será concluído amanhã às %s." tag="format"/>
         <e k="RVB_batteryChDialog" v="Tens a certeza que queres carregar a bateria do veículo por %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d hora" tag="format"/>
+        <e k="RVB_durationDialog" v="Duração total: %02d hora %02d min" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s hora" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Inspeção do veículo em andamento."/>
         <e k="RVB_alertmessage_repair" v="Reparo do veículo em andamento."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_ru.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_ru.xml
@@ -108,6 +108,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Техобслуживание транспортного средства будет завершено завтра в %s часов." tag="format"/>
         <e k="RVB_batteryChDialog" v="Вы уверены, что хотите зарядить аккумулятор вашего транспортного средства за %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d ч." tag="format"/>
+        <e k="RVB_durationDialog" v="Общая продолжительность: %02d ч. %02d мин" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s час." tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Проводится техосмотр транспортного средства."/>
         <e k="RVB_alertmessage_repair" v="Ремонт транспортного средства продолжается."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_tr.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_tr.xml
@@ -109,6 +109,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Araç servisi yarın saat %s’de tamamlanacak." tag="format"/>
         <e k="RVB_batteryChDialog" v="%s maliyetle araç aküsünü şarj etmek istediğinizden emin misiniz?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d saat" tag="format"/>
+        <e k="RVB_durationDialog" v="Toplam süre: %02d saat %02d dk" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s saat" tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Araç incelemesi devam ediyor."/>
         <e k="RVB_alertmessage_repair" v="Araç tamiri devam ediyor."/>

--- a/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_uk.xml
+++ b/FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_uk.xml
@@ -109,6 +109,7 @@
         <e k="RVB_periodicserviceDayDialog" v="Техогляд транспортного засобу буде закінченний завтра о %s годинні." tag="format"/>
         <e k="RVB_batteryChDialog" v="Ви впевнені, що хочете зарядити акумулятор вашого транспортного засобу за %s?" tag="format"/>
         <e k="RVB_operatingTime" v="%02d hour" tag="format"/>
+        <e k="RVB_durationDialog" v="Загальна тривалість: %02d год %02d хв" tag="format"/>
         <e k="RVB_shop_operatingTimeG" v="%s:%s година." tag="format"/>
         <e k="RVB_alertmessage_inspection" v="Проводиться техогляд транспортного засобу."/>
         <e k="RVB_alertmessage_repair" v="Ремонт транспортного засобу продовжується."/>


### PR DESCRIPTION
### Motivation
- The UI needs a full-duration string for dialogs in addition to the existing hour-only `RVB_operatingTime` entry. 
- The Hungarian text was provided and should be added exactly where localized strings are defined so dialogs display correct localized duration.

### Description
- Added a new `RVB_durationDialog` key to all existing translation files under `FS25_gameplay_Real_Vehicle_Breakdowns/translations` (14 locales). 
- Inserted each new key directly after the existing `RVB_operatingTime` entry for consistency of grouping. 
- Included the Hungarian string exactly as provided: `Teljes időtartam: %02d óra %02d perc`.
- Added matching localized strings for `en`, `de`, `fr`, `es`, `it`, `nl`, `pl`, `pt`, `br`, `ru`, `tr`, `uk`, and `cz`.

### Testing
- Verified the new key exists across files with `rg "RVB_durationDialog" FS25_gameplay_Real_Vehicle_Breakdowns/translations/l10n_*.xml` and it returned matches for all 14 locales. 
- Inspected file diffs to confirm a single localized insertion was added next to each `RVB_operatingTime` entry, totaling 14 insertions. 
- Confirmed the Hungarian entry matches the supplied text exactly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9caa4d6cc832b95cba5c80bc2678c)